### PR TITLE
Set default value of CVAR "gl_billboard_faces_camera" to "true".

### DIFF
--- a/src/gl/scene/gl_sprite.cpp
+++ b/src/gl/scene/gl_sprite.cpp
@@ -68,7 +68,7 @@ CVAR(Float, gl_sclipthreshold, 10.0, CVAR_ARCHIVE)
 CVAR(Float, gl_sclipfactor, 1.8, CVAR_ARCHIVE)
 CVAR(Int, gl_particles_style, 2, CVAR_ARCHIVE | CVAR_GLOBALCONFIG) // 0 = square, 1 = round, 2 = smooth
 CVAR(Int, gl_billboard_mode, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
-CVAR(Bool, gl_billboard_faces_camera, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+CVAR(Bool, gl_billboard_faces_camera, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, gl_billboard_particles, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Int, gl_enhanced_nv_stealth, 3, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CUSTOM_CVAR(Int, gl_fuzztype, 6, CVAR_ARCHIVE)


### PR DESCRIPTION
What problem this PR solves:
When you stand in place in VR, and look around you, the sprites on the floor and elsewhere rotate as you turn your head. This looks weird and wrong and breaks immersion. It looks much better for the sprites to remain mostly still as you look around. The CVAR I added to gzdoom back in 2016 fixes this problem. But you have to explicitly set it.

Workaround:
Add "+gl_billboard_faces_camera 1" to the command line in the launcher.

Real solution:
Especially because this branch is VR only, the value of this CVAR should default to "true". That's what this pull request does.

References:
https://forum.zdoom.org/viewtopic.php?p=904115#p904115
https://github.com/ZDoom/gzdoom/pull/50