### PR TITLE
MASTERNOSEE flag (#1601)

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -427,6 +427,7 @@ enum ActorFlag8
 	MF8_DONTFOLLOWPLAYERS	= 0x04000000,	// [inkoalawetrust] Friendly monster will not follow players.
 	MF8_SEEFRIENDLYMONSTERS	= 0X08000000,	// [inkoalawetrust] Hostile monster can see friendly monsters.
 	MF8_CROSSLINECHECK	= 0x10000000,	// [MC]Enables CanCrossLine virtual
+	MF8_MASTERNOSEE		= 0x20000000,	// Don't show object in first person if their master is the current camera.
 };
 
 // --- mobj.renderflags ---

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -348,6 +348,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF8, DONTFOLLOWPLAYERS, AActor, flags8),
 	DEFINE_FLAG(MF8, SEEFRIENDLYMONSTERS, AActor, flags8),
 	DEFINE_FLAG(MF8, CROSSLINECHECK, AActor, flags8),
+	DEFINE_FLAG(MF8, MASTERNOSEE, AActor, flags8),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),

--- a/src/swrenderer/scene/r_opaque_pass.cpp
+++ b/src/swrenderer/scene/r_opaque_pass.cpp
@@ -999,11 +999,22 @@ namespace swrenderer
 		// Don't waste time projecting sprites that are definitely not visible.
 		if (thing == nullptr ||
 			(thing->renderflags & RF_INVISIBLE) ||
+			(thing->renderflags & RF_MAYBEINVISIBLE) ||
 			!thing->RenderStyle.IsVisible(thing->Alpha) ||
 			!thing->IsVisibleToPlayer() ||
 			!thing->IsInsideVisibleAngles())
 		{
 			return false;
+		}
+
+		if ((thing->flags8 & MF8_MASTERNOSEE) && thing->master != nullptr)
+		{
+			// Make MASTERNOSEE actors invisible if their master
+			// is invisible due to viewpoint shenanigans.
+			if (thing->master->renderflags & RF_MAYBEINVISIBLE)
+			{
+				return false;
+			}
 		}
 
 		// check renderrequired vs ~r_rendercaps, if anything matches we don't support that feature,

--- a/src/swrenderer/scene/r_portal.cpp
+++ b/src/swrenderer/scene/r_portal.cpp
@@ -392,7 +392,7 @@ namespace swrenderer
 
 					if (dist1 + dist2 < distp + 1)
 					{
-						viewpoint.camera->renderflags |= RF_INVISIBLE;
+						viewpoint.camera->renderflags |= RF_MAYBEINVISIBLE;
 					}
 				}
 			}

--- a/src/swrenderer/scene/r_scene.cpp
+++ b/src/swrenderer/scene/r_scene.cpp
@@ -173,7 +173,7 @@ namespace swrenderer
 		// Never draw the player unless in chasecam mode
 		if (!MainThread()->Viewport->viewpoint.showviewer)
 		{
-			MainThread()->Viewport->viewpoint.camera->renderflags |= RF_INVISIBLE;
+			MainThread()->Viewport->viewpoint.camera->renderflags |= RF_MAYBEINVISIBLE;
 		}
 
 		RenderThreadSlices();


### PR DESCRIPTION
Makes it so that if an actor's master is invisible due to camera/mirror/portal shenanigans, then the actor will also be invisible. Name based off of an Unreal Engine flag that does the exact same thing.

Co-authored-by: Christoph Oelckers <coelckers@users.noreply.github.com>