### PR TITLE
Models refactoring required for A_ChangeModel update

### DIFF
--- a/src/gl/textures/gl_texture.cpp
+++ b/src/gl/textures/gl_texture.cpp
@@ -677,7 +677,7 @@ void gl_PrecacheTexture(uint8_t *texhitlist, TMap<PClassActor*, bool> &actorhitl
 			FSpriteModelFrame * smf = FindModelFrame(cls, state.sprite, state.Frame, false);
 			if (smf != NULL)
 			{
-				for (int i = 0; i < MAX_MODELS_PER_FRAME; i++)
+				for (int i = 0; i < smf->modelsAmount; i++)
 				{
 					if (smf->skinIDs[i].isValid())
 					{

--- a/src/r_data/models/models.cpp
+++ b/src/r_data/models/models.cpp
@@ -609,25 +609,18 @@ static void ParseModelDefLump(int Lump)
 			{
 				smf.modelsAmount = MIN_MODELS;
 			}
-			//Allocate TArrays
-			smf.modelIDs.Alloc(smf.modelsAmount);
-			smf.skinIDs.Alloc(smf.modelsAmount);
-			smf.surfaceskinIDs.Alloc(smf.modelsAmount * MD3_MAX_SURFACES);
-			smf.modelframes.Alloc(smf.modelsAmount);
-			//Make sure all modelIDs are -1 by default
-			for (auto& modelID : smf.modelIDs)
+
+			const auto initArray = [](auto& array, const unsigned count, const auto value)
 			{
-				modelID = -1;
-			}
-			//Make sure no TArray elements of type FTextureID are null. These elements will have a textureid (FTextureID.texnum) of 0.
-			for (auto& skinID : smf.skinIDs)
-			{
-				skinID = FTextureID(FNullTextureID());
-			}
-			for (auto& surfaceskinID : smf.surfaceskinIDs)
-			{
-				surfaceskinID = FTextureID(FNullTextureID());
-			}
+				array.Alloc(count);
+				std::fill(array.begin(), array.end(), value);
+			};
+
+			initArray(smf.modelIDs, smf.modelsAmount, -1);
+			initArray(smf.skinIDs, smf.modelsAmount, FNullTextureID());
+			initArray(smf.surfaceskinIDs, smf.modelsAmount * MD3_MAX_SURFACES, FNullTextureID());
+			initArray(smf.modelframes, smf.modelsAmount, 0);
+
 			sc.RestorePos(scPos);
 			sc.MustGetStringName("{");
 			while (!sc.CheckString("}"))

--- a/src/r_data/models/models.cpp
+++ b/src/r_data/models/models.cpp
@@ -604,10 +604,10 @@ static void ParseModelDefLump(int Lump)
 					smf.modelsAmount = index + 1;
 				}
 			}
-			//Make sure modelsAmount is at least equal to MD3_MIN_MODELS(4) to ensure compatibility with old mods
-			if (smf.modelsAmount < MD3_MIN_MODELS)
+			//Make sure modelsAmount is at least equal to MIN_MODELS(4) to ensure compatibility with old mods
+			if (smf.modelsAmount < MIN_MODELS)
 			{
-				smf.modelsAmount = MD3_MIN_MODELS;
+				smf.modelsAmount = MIN_MODELS;
 			}
 			//Allocate TArrays
 			smf.modelIDs.Alloc(smf.modelsAmount);

--- a/src/r_data/models/models.h
+++ b/src/r_data/models/models.h
@@ -41,6 +41,7 @@ enum { VX, VZ, VY };
 #define MD3_MAGIC			0x33504449
 #define NUMVERTEXNORMALS	162
 #define MD3_MAX_SURFACES	32
+#define MD3_MIN_MODELS	4
 
 FTextureID LoadSkin(const char * path, const char * fn);
 
@@ -415,7 +416,6 @@ public:
 
 
 
-#define MAX_MODELS_PER_FRAME 4
 
 //
 // [BB] Model rendering flags.
@@ -439,10 +439,11 @@ enum
 
 struct FSpriteModelFrame
 {
-	int modelIDs[MAX_MODELS_PER_FRAME];
-	FTextureID skinIDs[MAX_MODELS_PER_FRAME];
-	FTextureID surfaceskinIDs[MAX_MODELS_PER_FRAME][MD3_MAX_SURFACES];
-	int modelframes[MAX_MODELS_PER_FRAME];
+	uint8_t modelsAmount = 0;
+	TArray<int> modelIDs;
+	TArray<FTextureID> skinIDs;
+	TArray<FTextureID> surfaceskinIDs;
+	TArray<int> modelframes;
 	float xscale, yscale, zscale;
 	// [BB] Added zoffset, rotation parameters and flags.
 	// Added xoffset, yoffset

--- a/src/r_data/models/models.h
+++ b/src/r_data/models/models.h
@@ -41,7 +41,7 @@ enum { VX, VZ, VY };
 #define MD3_MAGIC			0x33504449
 #define NUMVERTEXNORMALS	162
 #define MD3_MAX_SURFACES	32
-#define MD3_MIN_MODELS	4
+#define MIN_MODELS	4
 
 FTextureID LoadSkin(const char * path, const char * fn);
 

--- a/src/r_data/models/models.h
+++ b/src/r_data/models/models.h
@@ -452,10 +452,9 @@ struct FSpriteModelFrame
 	float rotationCenterX, rotationCenterY, rotationCenterZ;
 	float rotationSpeed;
 	unsigned int flags;
-	const PClass * type;
+	const PClass * type;  // data from type, sprite and frame up to hashnext are used for hashing, no other fields should be added between type and hashnext
 	short sprite;
 	short frame;
-	FState * state;	// for later!
 	int hashnext;
 	float angleoffset;
 	// added pithoffset, rolloffset.

--- a/src/r_data/models/models_md3.cpp
+++ b/src/r_data/models/models_md3.cpp
@@ -307,7 +307,7 @@ void FMD3Model::AddSkins(uint8_t *hitlist)
 	for (unsigned i = 0; i < Surfaces.Size(); i++)
 	{
 		int ssIndex = i + curMDLIndex * MD3_MAX_SURFACES;
-		if (curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
+		if (curSpriteMDLFrame && curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
 		{
 			hitlist[curSpriteMDLFrame->surfaceskinIDs[ssIndex].GetIndex()] |= FTextureManager::HIT_Flat;
 		}
@@ -358,14 +358,17 @@ void FMD3Model::RenderFrame(FModelRenderer *renderer, FTexture * skin, int frame
 		FTexture *surfaceSkin = skin;
 		if (!surfaceSkin)
 		{
-			int ssIndex = i + curMDLIndex * MD3_MAX_SURFACES;
-			if (curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
+			if (curSpriteMDLFrame)
 			{
-				surfaceSkin = TexMan(curSpriteMDLFrame->surfaceskinIDs[ssIndex]);
-			}
-			else if (surf->numSkins > 0 && surf->Skins[0].isValid())
-			{
-				surfaceSkin = TexMan(surf->Skins[0]);
+				int ssIndex = i + curMDLIndex * MD3_MAX_SURFACES;
+				if (curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
+				{
+					surfaceSkin = TexMan(curSpriteMDLFrame->surfaceskinIDs[ssIndex]);
+				}
+				else if (surf->numSkins > 0 && surf->Skins[0].isValid())
+				{
+					surfaceSkin = TexMan(surf->Skins[0]);
+				}
 			}
 
 			if (!surfaceSkin)

--- a/src/r_data/models/models_md3.cpp
+++ b/src/r_data/models/models_md3.cpp
@@ -306,9 +306,10 @@ void FMD3Model::AddSkins(uint8_t *hitlist)
 {
 	for (unsigned i = 0; i < Surfaces.Size(); i++)
 	{
-		if (curSpriteMDLFrame->surfaceskinIDs[curMDLIndex][i].isValid())
+		int ssIndex = i + curMDLIndex * MD3_MAX_SURFACES;
+		if (curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
 		{
-			hitlist[curSpriteMDLFrame->surfaceskinIDs[curMDLIndex][i].GetIndex()] |= FTextureManager::HIT_Flat;
+			hitlist[curSpriteMDLFrame->surfaceskinIDs[ssIndex].GetIndex()] |= FTextureManager::HIT_Flat;
 		}
 
 		MD3Surface * surf = &Surfaces[i];
@@ -357,9 +358,10 @@ void FMD3Model::RenderFrame(FModelRenderer *renderer, FTexture * skin, int frame
 		FTexture *surfaceSkin = skin;
 		if (!surfaceSkin)
 		{
-			if (curSpriteMDLFrame->surfaceskinIDs[curMDLIndex][i].isValid())
+			int ssIndex = i + curMDLIndex * MD3_MAX_SURFACES;
+			if (curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
 			{
-				surfaceSkin = TexMan(curSpriteMDLFrame->surfaceskinIDs[curMDLIndex][i]);
+				surfaceSkin = TexMan(curSpriteMDLFrame->surfaceskinIDs[ssIndex]);
 			}
 			else if (surf->numSkins > 0 && surf->Skins[0].isValid())
 			{

--- a/src/r_data/models/models_obj.cpp
+++ b/src/r_data/models/models_obj.cpp
@@ -631,7 +631,7 @@ void FOBJModel::RenderFrame(FModelRenderer *renderer, FTexture * skin, int frame
 		OBJSurface *surf = &surfaces[i];
 
 		FTexture *userSkin = skin;
-		if (!userSkin)
+		if (!userSkin && curSpriteMDLFrame)
 		{
 			int ssIndex = i + curMDLIndex * MD3_MAX_SURFACES;
 			if (i < MD3_MAX_SURFACES && curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
@@ -666,7 +666,7 @@ void FOBJModel::AddSkins(uint8_t* hitlist)
 	for (size_t i = 0; i < surfaces.Size(); i++)
 	{
 		size_t ssIndex = i + curMDLIndex * MD3_MAX_SURFACES;
-		if (i < MD3_MAX_SURFACES && curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
+		if (curSpriteMDLFrame && i < MD3_MAX_SURFACES && curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
 		{
 			// Precache skins manually reassigned by the user.
 			// On OBJs with lots of skins, such as Doom map OBJs exported from GZDB,

--- a/src/r_data/models/models_obj.cpp
+++ b/src/r_data/models/models_obj.cpp
@@ -633,9 +633,10 @@ void FOBJModel::RenderFrame(FModelRenderer *renderer, FTexture * skin, int frame
 		FTexture *userSkin = skin;
 		if (!userSkin)
 		{
-			if (i < MD3_MAX_SURFACES && curSpriteMDLFrame->surfaceskinIDs[curMDLIndex][i].isValid())
+			int ssIndex = i + curMDLIndex * MD3_MAX_SURFACES;
+			if (i < MD3_MAX_SURFACES && curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
 			{
-				userSkin = TexMan(curSpriteMDLFrame->surfaceskinIDs[curMDLIndex][i]);
+				userSkin = TexMan(curSpriteMDLFrame->surfaceskinIDs[ssIndex]);
 			}
 			else if (surf->skin.isValid())
 			{
@@ -664,13 +665,14 @@ void FOBJModel::AddSkins(uint8_t* hitlist)
 {
 	for (size_t i = 0; i < surfaces.Size(); i++)
 	{
-		if (i < MD3_MAX_SURFACES && curSpriteMDLFrame->surfaceskinIDs[curMDLIndex][i].isValid())
+		size_t ssIndex = i + curMDLIndex * MD3_MAX_SURFACES;
+		if (i < MD3_MAX_SURFACES && curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
 		{
 			// Precache skins manually reassigned by the user.
 			// On OBJs with lots of skins, such as Doom map OBJs exported from GZDB,
 			// there may be too many skins for the user to manually change, unless
 			// the limit is bumped or surfaceskinIDs is changed to a TArray<FTextureID>.
-			hitlist[curSpriteMDLFrame->surfaceskinIDs[curMDLIndex][i].GetIndex()] |= FTextureManager::HIT_Flat;
+			hitlist[curSpriteMDLFrame->surfaceskinIDs[ssIndex].GetIndex()] |= FTextureManager::HIT_Flat;
 			return; // No need to precache skin that was replaced
 		}
 

--- a/src/r_data/models/models_ue1.cpp
+++ b/src/r_data/models/models_ue1.cpp
@@ -240,8 +240,9 @@ void FUE1Model::RenderFrame( FModelRenderer *renderer, FTexture *skin, int frame
 		FTexture *sskin = skin;
 		if ( !sskin )
 		{
-			if ( curSpriteMDLFrame->surfaceskinIDs[curMDLIndex][groups[i].texNum].isValid() )
-				sskin = TexMan(curSpriteMDLFrame->surfaceskinIDs[curMDLIndex][groups[i].texNum]);
+			int ssIndex = groups[i].texNum + curMDLIndex * MD3_MAX_SURFACES;
+			if (curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
+				sskin = TexMan(curSpriteMDLFrame->surfaceskinIDs[ssIndex]);
 			if ( !sskin )
 			{
 				vofs += vsize;
@@ -300,9 +301,12 @@ void FUE1Model::BuildVertexBuffer( FModelRenderer *renderer )
 
 void FUE1Model::AddSkins( uint8_t *hitlist )
 {
-	for ( int i=0; i<numGroups; i++ )
-		if ( curSpriteMDLFrame->surfaceskinIDs[curMDLIndex][groups[i].texNum].isValid() )
-			hitlist[curSpriteMDLFrame->surfaceskinIDs[curMDLIndex][groups[i].texNum].GetIndex()] |= FTextureManager::HIT_Flat;
+	for (int i = 0; i < numGroups; i++)
+	{
+		int ssIndex = groups[i].texNum + curMDLIndex * MD3_MAX_SURFACES;
+		if (curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
+			hitlist[curSpriteMDLFrame->surfaceskinIDs[ssIndex].GetIndex()] |= FTextureManager::HIT_Flat;
+	}
 }
 
 FUE1Model::~FUE1Model()

--- a/src/r_data/models/models_ue1.cpp
+++ b/src/r_data/models/models_ue1.cpp
@@ -241,7 +241,7 @@ void FUE1Model::RenderFrame( FModelRenderer *renderer, FTexture *skin, int frame
 		if ( !sskin )
 		{
 			int ssIndex = groups[i].texNum + curMDLIndex * MD3_MAX_SURFACES;
-			if (curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
+			if (curSpriteMDLFrame && curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
 				sskin = TexMan(curSpriteMDLFrame->surfaceskinIDs[ssIndex]);
 			if ( !sskin )
 			{
@@ -304,7 +304,7 @@ void FUE1Model::AddSkins( uint8_t *hitlist )
 	for (int i = 0; i < numGroups; i++)
 	{
 		int ssIndex = groups[i].texNum + curMDLIndex * MD3_MAX_SURFACES;
-		if (curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
+		if (curSpriteMDLFrame && curSpriteMDLFrame->surfaceskinIDs[ssIndex].isValid())
 			hitlist[curSpriteMDLFrame->surfaceskinIDs[ssIndex].GetIndex()] |= FTextureManager::HIT_Flat;
 	}
 }


### PR DESCRIPTION
The two TArrays of type FTextureID skinIDs and surfaceskinIDs no longer have any null elements. These elements will have a textureid (FTextureID.texnum) of 0.

**With these changes 3d models don't work, they are just replaced with sprites.**
**Strange enough this problem is not present on QuestZDoom debug and release.**

**From my test just by adding a `TArray` variable (even if not used) into the `struct FSpriteModelFrame` cause the problem.**