### PR TITLE
Toggleable player following. (#1583)

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -424,6 +424,7 @@ enum ActorFlag8
 	MF8_MAP07BOSS2		= 0x00800000,	// MBF21 boss death.
 	MF8_AVOIDHAZARDS	= 0x01000000,	// MBF AI enhancement.
 	MF8_STAYONLIFT		= 0x02000000,	// MBF AI enhancement.
+	MF8_DONTFOLLOWPLAYERS	= 0x04000000,	// [inkoalwetrust] Friendly monster will not follow players.
 };
 
 // --- mobj.renderflags ---

--- a/src/p_enemy.cpp
+++ b/src/p_enemy.cpp
@@ -1107,7 +1107,7 @@ void P_RandomChaseDir (AActor *actor)
 	int turndir;
 
 	// Friendly monsters like to head toward a player
-	if (actor->flags & MF_FRIENDLY)
+	if (actor->flags & MF_FRIENDLY && !(actor->flags8 & MF8_DONTFOLLOWPLAYERS))
 	{
 		AActor *player;
 		DVector2 delta;

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -345,6 +345,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF8, MAP07BOSS2, AActor, flags8),
 	DEFINE_FLAG(MF8, AVOIDHAZARDS, AActor, flags8),
 	DEFINE_FLAG(MF8, STAYONLIFT, AActor, flags8),
+	DEFINE_FLAG(MF8, DONTFOLLOWPLAYERS, AActor, flags8),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),


### PR DESCRIPTION
* Added MF8_DONTFOLLOWPLAYERS.

Added the MF8_DONTFOLLOWPLAYERS flag, which allows friendly monsters to not follow their FriendPlayer when they have no target or goal left to head to.

* Changed the order that the DONTFOLLOWPLAYERS check runs in.

This is done to not produce unnecessary overhead on hostile monsters.