### PR TITLE
fix: fix custom shaders not working on android devices

### DIFF
--- a/src/gl/shaders/gl_postprocessshader.cpp
+++ b/src/gl/shaders/gl_postprocessshader.cpp
@@ -116,6 +116,15 @@ void PostProcessShaderInstance::Run()
 bool PostProcessShaderInstance::IsShaderSupported()
 {
 	int activeShaderVersion = (int)round(gl.glslversion * 10) * 10;
+	if (gl.es)
+	{
+		if (activeShaderVersion >= 200)
+			activeShaderVersion = 410;
+		if (activeShaderVersion >= 300)
+			activeShaderVersion = 430;
+		if (activeShaderVersion >= 310)
+			activeShaderVersion = 450;
+	}
 	return activeShaderVersion >= Desc->ShaderVersion;
 }
 


### PR DESCRIPTION
IsShaderSupported only check against OpenGL version, so this method return always false when running on Android with OpenGL ES because of version mismatch. I put what I think is the right conversion between opengl desktop and mobile versions so custom shaders should work on mobile as well if compatibles