### PR TITLE
fix: set gl_custompost to false by default and save cvar to config, a…

### DIFF
--- a/src/gl/shaders/gl_postprocessshader.cpp
+++ b/src/gl/shaders/gl_postprocessshader.cpp
@@ -38,7 +38,7 @@
 #include "textures/textures.h"
 #include "textures/bitmap.h"
 
-CVAR(Bool, gl_custompost, true, 0)
+CVAR(Bool, gl_custompost, true, CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
 
 TArray<PostProcessShader> PostProcessShaders;
 

--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -2846,6 +2846,7 @@ GLPREFMNU_SWLMBANDED			= "Banded SW Lightmode";
 GLPREFMNU_VRIPD					= "Distance Between Your Eyes";
 GLPREFMNU_VRSCREENDIST			= "Distance From Your Screen";
 GLPREFMNU_RENDERSKYDOME			= "Render the skydome";
+GLPREFMNU_CUSTOMPOST			= "Custom post-processing shaders";
 
 // Option Values
 OPTVAL_SMART 				= "Smart";

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2993,6 +2993,8 @@ OptionMenu "PostProcessMenu" protected
 	Slider "$GLPREFMNU_PALTONEMAPPOWER",		gl_paltonemap_powtable,			0.2, 3.0, 0.1, 1
 	Option "$GLPREFMNU_PALTONEMAPORDER",		gl_paltonemap_reverselookup,	"LookupOrder"
 	StaticText " "
+	Option "$GLPREFMNU_CUSTOMPOST",		 		gl_custompost,					"OnOff"
+	StaticText " "
 	SafeCommand "$OPTMNU_DEFAULTS", "resetcvar gl_bloom gl_lens gl_ssao gl_ssao_portals gl_fxaa gl_dither_bpc gl_tonemap gl_paltonemap_powtable gl_paltonemap_reverselookup"
 }
 


### PR DESCRIPTION
…dd new menu option to toggle custom postprocessing shaders

I enabled the use of custom shaders on a recent update (see refs), previously always disabled on mobile, by doing this you will get more errors if these shaders have not been written correctly. This fix will address the problem. This cvar toggle custom shaders, to avoid breaking things that worked previously.

Refs: 8e767e1c5b300d781efeb39e35e030e32413426e