### PR TITLE
feat: backported scaling options for the 2D drawer from Raze.

### DIFF
--- a/src/v_draw.cpp
+++ b/src/v_draw.cpp
@@ -428,6 +428,8 @@ bool DCanvas::SetTextureParms(DrawParms *parms, FTexture *img, double xx, double
 		{
 			parms->destheight = img->GetScaledHeightDouble();
 		}
+		parms->destwidth *= parms->patchscalex;
+		parms->destheight *= parms->patchscaley;
 
 		switch (parms->cleanmode)
 		{
@@ -654,6 +656,7 @@ bool DCanvas::ParseDrawTextureTags(FTexture *img, double x, double y, uint32_t t
 	parms->monospace = EMonospacing::MOff;
 	parms->spacing = 0;
 	parms->fsscalemode = -1;
+	parms->patchscalex = parms->patchscaley = 1;
 
 	// Parse the tag list for attributes. (For floating point attributes,
 	// consider that the C ABI dictates that all floats be promoted to
@@ -987,6 +990,14 @@ bool DCanvas::ParseDrawTextureTags(FTexture *img, double x, double y, uint32_t t
 			{
 				//parms->shadowAlpha = 0;
 			}
+			break;
+
+		case DTA_ScaleX:
+			parms->patchscalex = ListGetDouble(tags);
+			break;
+
+		case DTA_ScaleY:
+			parms->patchscaley = ListGetDouble(tags);
 			break;
 
 		case DTA_Masked:

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -164,6 +164,8 @@ enum
 
 	DTA_CleanTop,			// Like DTA_Clean but aligns to the top of the screen instead of the center.
 
+	DTA_ScaleX,
+	DTA_ScaleY,
 };
 
 enum EMonospacing : int
@@ -230,6 +232,7 @@ struct DrawParms
 	bool virtBottom;
 	double srcx, srcy;
 	double srcwidth, srcheight;
+	double patchscalex, patchscaley;
 	bool burn;
 	int8_t fsscalemode;
 };

--- a/wadsrc/static/zscript/base.zs
+++ b/wadsrc/static/zscript/base.zs
@@ -192,6 +192,8 @@ enum DrawTextureTags
 
 	DTA_CleanTop,			// Like DTA_Clean but aligns to the top of the screen instead of the center.
 
+	DTA_ScaleX,
+	DTA_ScaleY,
 };
 
 class Shape2DTransform : Object native


### PR DESCRIPTION
Cherry-picked from: dbf2d4d7d740babc695c442753326d08376beb66